### PR TITLE
remove Kernel.php from psalm.xml

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -40,12 +40,6 @@
 
         <PropertyNotSetInConstructor errorLevel="info"/>
 
-        <MethodSignatureMismatch>
-            <errorLevel type="info">
-                <file name="src/Kernel.php"/>
-            </errorLevel>
-        </MethodSignatureMismatch>
-
         <DeprecatedMethod>
             <errorLevel type="info">
                 <referencedMethod name="GuzzleHttp\Client::getConfig" />


### PR DESCRIPTION
Kernel.php does not exist anymore in src directory, as it's covered by shopware/core. The exclusion from psalm is therefor not needed anymore.